### PR TITLE
DECAF-161 Enhance TypeORM models with dynamic keys and type validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -615,9 +615,9 @@
       }
     },
     "node_modules/@decaf-ts/core": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@decaf-ts/core/-/core-0.5.10.tgz",
-      "integrity": "sha512-l5hIraA5qaWQaTKPaC5g/ApbciqZdW+cyQXCjQyN4nKcVdNoHAOoWXpH7tEQmc66LYbtvCrm1J32L+tQ5cF5RQ==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@decaf-ts/core/-/core-0.5.11.tgz",
+      "integrity": "sha512-tG35/1eXajW39JAudiWhn7vXLa0x2W9NQC25v1zGB9zdpKxhxYR0uLyCwS22sYvLlowPpZofMa5cyFB5pRe4KQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -669,9 +669,9 @@
       }
     },
     "node_modules/@decaf-ts/injectable-decorators": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@decaf-ts/injectable-decorators/-/injectable-decorators-1.6.2.tgz",
-      "integrity": "sha512-IKIKBp2aAEEKKAEe0nkngevt6ebuSt1e4CS0Qe+yQEsqWr7VHIvWin17MaEoVrETClL4ec9hOMq8Ovo1hXN7ew==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@decaf-ts/injectable-decorators/-/injectable-decorators-1.6.3.tgz",
+      "integrity": "sha512-x/Cfe5qxiU5Lb7Xg1IdzLI4EMxBB3i486ulL2J/yY0iZnJ9Mn6ucRp6aZUGKpoxcxUFHF4gnaYEsLjGHHY6Txg==",
       "license": "MIT",
       "peer": true,
       "engines": {


### PR DESCRIPTION
### Summary

This pull request enhances TypeORM model decorators to support dynamic primary key handling and enforce type validation. Additionally, it updates the dependencies to their latest versions to ensure compatibility and improvements.